### PR TITLE
Server

### DIFF
--- a/src/NeTrainSim/traindefinition/traincomponent.cpp
+++ b/src/NeTrainSim/traindefinition/traincomponent.cpp
@@ -12,6 +12,8 @@ void TrainComponent::resetTimeStepConsumptions() {
 	this->energyRegenerated = 0.0;
     this->cumEnergyConsumed = 0.0; // the step energy consumption of multiple technologies (e.g hybrid)
     this->cumEnergyRegenerated = 0.0; // the step energy regeneration of multiple technologies (e.g hybrid)
+    this->carbonDioxideEmission = 0.0;
+    this->cumCarbonDioxideEmission = 0.0;
 }
 
 void TrainComponent::setCurrentWeight(double newCurrentWeight) {

--- a/src/NeTrainSimGUI/gui/netrainsimmainwindow.cpp
+++ b/src/NeTrainSimGUI/gui/netrainsimmainwindow.cpp
@@ -1493,8 +1493,7 @@ Vector<Map<std::string,
                                 std::stod(record["XScale"]),
                            std::stod(record["YCoordinate"]) *
                                std::stod(record["YScale"]));
-    }
-
+    }    
     return records;
 }
 
@@ -1503,7 +1502,6 @@ Vector<Map<std::string,
 void NeTrainSim::updateNodesPlot(CustomPlot &plot, QVector<double>xData,
                                  QVector<double>yData,
                                  QVector<QString> labels, bool showLabels) {
-
 
     // check the plot has at least 1 graph
     if (plot.graphCount() < 1) { return; }
@@ -1546,6 +1544,14 @@ void NeTrainSim::updateNodesPlot(CustomPlot &plot, QVector<double>xData,
     ymin = ymin - 0.1 * ymin;
     double ymax = *std::max_element(yData.begin(), yData.end());
     ymax = ymax + 0.1 * ymax;
+
+    // Add minimum range to prevent zero-range issues
+    if (ymin == ymax) {
+        double value = ymin;
+        ymin = value - 1.0;  // Use a reasonable minimum range
+        ymax = value + 1.0;
+    }
+
     // set the range of the y-axis
     plot.yAxis->setRangeLower(ymin);
     plot.yAxis->setRangeUpper(ymax);
@@ -3020,10 +3026,15 @@ void NeTrainSim::loadNodesDataToTable(
                      &QDoubleSpinBox::valueChanged,
                      this, &NeTrainSim::updateTheNodesPlotData);
 
-    this->forceReplotNodes();
+    this->updateTheNodesPlotData();
+    this->updateTheLinksPlotData();
 
-    // in case the user loaded the links data first
-    this->forceReplotLinks();
+    this->updateNodesPlot(*(ui->plot_createNetwork),
+                          this->nodesXData, this->nodesYData,
+                          this->nodesLabelData);
+    this->updateLinksPlot(*(ui->plot_createNetwork),
+                          this->linksStartNodeIDs, this->linksEndNodeIDs);
+
 
 }
 
@@ -3150,7 +3161,14 @@ void NeTrainSim::loadLinksDataToTable(
     QObject::connect(ui->table_newLinks, &QTableWidget::cellChanged,
                      this, &NeTrainSim::updateTheLinksPlotData);
 
-    this->forceReplotLinks();
+    this->updateTheNodesPlotData();
+    this->updateTheLinksPlotData();
+
+    this->updateNodesPlot(*(ui->plot_createNetwork),
+                          this->nodesXData, this->nodesYData,
+                          this->nodesLabelData);
+    this->updateLinksPlot(*(ui->plot_createNetwork),
+                          this->linksStartNodeIDs, this->linksEndNodeIDs);
 
 }
 


### PR DESCRIPTION
Adds a safeguard to handle zero-range issues in y-axis scaling by ensuring a minimum range for plots.

Replaces calls to `forceReplotNodes` and `forceReplotLinks` with direct updates to node and link plots, ensuring the plots are refreshed with accurate data after loading.

Enhances readability by removing unnecessary whitespace.

Improves plot stability and user experience by ensuring proper data visualization.