### PR TITLE
feat: speed-dependent braking model, blended braking fix, and GUI improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,7 @@ if(BUILD_GUI)
     elseif(APPLE)
         set(KDREPORTS_DIR "/usr/local/KDAB/KDReports-2.3.95/lib/cmake/KDReports-qt6" CACHE PATH "Path to KDReports CMake directory")
     elseif(UNIX)
-        set(KDREPORTS_DIR "/usr/local/KDAB/KDReports-2.3.95/lib/cmake/KDReports-qt6" CACHE PATH "Path to KDReports CMake directory")
+        set(KDREPORTS_DIR "/usr/local/${CMAKE_BUILD_TYPE}/lib/cmake/KDReports-qt6" CACHE PATH "Path to KDReports CMake directory")
     endif()
 
     # Use the KDReports CMake package

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ if(BUILD_SERVER)
     elseif(UNIX)
         # Linux-specific paths
         set(CONTAINER_SEARCH_PATHS "/usr/local/lib/cmake/Container" CACHE PATH "Default path to container's library on Linux")
-        set(RABBITMQ_CMAKE_DIR "/usr/local/lib/cmake/rabbitmq-c" CACHE PATH "Default path to RabbitMQ-C library on Linux")
+        set(RABBITMQ_CMAKE_DIR "/usr/local/${CMAKE_BUILD_TYPE}/lib/cmake/rabbitmq-c" CACHE PATH "Default path to RabbitMQ-C library on Linux")
     else()
         message(FATAL_ERROR "Unsupported platform. Please set paths for CONTAINER_CMAKE_DIR and RABBITMQ_CMAKE_DIR manually.")
     endif()

--- a/src/NeTrainSim/traindefinition/car.cpp
+++ b/src/NeTrainSim/traindefinition/car.cpp
@@ -76,6 +76,12 @@ Car::Car(double carLength_m, double carDragCoef,
 
     } // end else if
 
+    if (this->carType == TrainTypes::CarType::cargo) {
+        this->brakedWeightRatio = EC::DefaultCarBrakedWeightRatio_Cargo;
+    } else {
+        this->brakedWeightRatio = EC::DefaultCarBrakedWeightRatio_Tender;
+    }
+
     this->hostLink = std::shared_ptr<NetLink>(); // assign empty placeholder
     this->trackCurvature = 0; // zero initialized
     this->trackGrade = 0;   // zero initialized

--- a/src/NeTrainSim/traindefinition/energyconsumption.cpp
+++ b/src/NeTrainSim/traindefinition/energyconsumption.cpp
@@ -159,4 +159,16 @@ namespace EC {
         return fuelConversionFactor_carTypes[carType];
     }
 
+    double getBrakeShoeFriction(double speed_mps,
+                                TrainTypes::BrakeShoeType shoeType) {
+        double v_kmh = speed_mps * 3.6;
+        switch (shoeType) {
+        case TrainTypes::BrakeShoeType::composition:
+            return 0.36 * (v_kmh + 150.0) / (2.0 * v_kmh + 150.0);
+        case TrainTypes::BrakeShoeType::castIron:
+        default:
+            return 0.6 * (v_kmh + 100.0) / (5.0 * v_kmh + 100.0);
+        }
+    }
+
 }

--- a/src/NeTrainSim/traindefinition/energyconsumption.h
+++ b/src/NeTrainSim/traindefinition/energyconsumption.h
@@ -301,6 +301,25 @@ namespace EC {
      * @returns The fuel conversion factor.
      */
     double getFuelConversionFactor(TrainTypes::CarType carType);
+
+    /** (Immutable) the speed below which dynamic braking fades to zero (km/h) */
+    static constexpr double DynamicBrakingFadeSpeed_kmh = 15.0;
+
+    /**
+     * Gets the brake shoe friction coefficient using the Karwatzki model.
+     *
+     * @details For cast-iron shoes (UIC standard):
+     *   mu(v) = 0.6 * (v_kmh + 100) / (5 * v_kmh + 100)
+     * For composition shoes:
+     *   mu(v) = 0.36 * (v_kmh + 150) / (2 * v_kmh + 150)
+     *
+     * @param speed_mps  Train speed in m/s.
+     * @param shoeType   Type of brake shoe (default: castIron).
+     * @returns The brake shoe friction coefficient (dimensionless).
+     */
+    double getBrakeShoeFriction(double speed_mps,
+                                TrainTypes::BrakeShoeType shoeType =
+                                    TrainTypes::BrakeShoeType::castIron);
 }
 
 

--- a/src/NeTrainSim/traindefinition/energyconsumption.h
+++ b/src/NeTrainSim/traindefinition/energyconsumption.h
@@ -302,6 +302,15 @@ namespace EC {
      */
     double getFuelConversionFactor(TrainTypes::CarType carType);
 
+    /** (Immutable) gravitational acceleration (m/s^2) */
+    static constexpr double g = 9.8066;
+    /** (Immutable) default braked weight ratio for locomotives */
+    static constexpr double DefaultLocomotiveBrakedWeightRatio = 0.9;
+    /** (Immutable) default braked weight ratio for cargo cars */
+    static constexpr double DefaultCarBrakedWeightRatio_Cargo = 0.6;
+    /** (Immutable) default braked weight ratio for tender cars */
+    static constexpr double DefaultCarBrakedWeightRatio_Tender = 0.7;
+
     /** (Immutable) the speed below which dynamic braking fades to zero (km/h) */
     static constexpr double DynamicBrakingFadeSpeed_kmh = 15.0;
 

--- a/src/NeTrainSim/traindefinition/locomotive.cpp
+++ b/src/NeTrainSim/traindefinition/locomotive.cpp
@@ -541,12 +541,16 @@ double Locomotive::getEnergyConsumption(double& LocomotiveVirtualTractivePower,
 		return EC;
 	}
     else {
-        // get regenerative eff
+        // Blended braking: only the dynamic portion (motor as generator) is recoverable.
+        // Friction braking energy is dissipated as heat.
+        double recoverablePower =
+            -this->getRecoverableBrakingPower(tractivePower, trainSpeed);
+
         double regenerativeEff =
             this->getRegenerativeEffeciency(tractivePower,
                                             trainAcceleration, trainSpeed);
 
-        return ((tractivePower * regenerativeEff + this->auxiliaryPower) *
+        return ((recoverablePower * regenerativeEff + this->auxiliaryPower) *
                 EC::getDriveLineEff(trainSpeed,
                                     this->currentLocNotch,
                                     std::abs(powerPortion),
@@ -554,7 +558,7 @@ double Locomotive::getEnergyConsumption(double& LocomotiveVirtualTractivePower,
                                     this->hybridMethod) *
                 unitConversionFactor);
 
-	}
+    }
 }
 
 double Locomotive::getUsedPowerPortion(double trainSpeed,
@@ -566,6 +570,25 @@ double Locomotive::getUsedPowerPortion(double trainSpeed,
     // it is limited because at the begining of the deceleration, the
     // power is very high
     return std::min((LocomotiveVirtualTractivePower) / maxPower, 1.0);
+}
+
+double Locomotive::getRecoverableBrakingPower(double totalBrakingPower,
+                                              double trainSpeed)
+{
+    if (!TrainTypes::locomotiveRechargableTechnologies.exist(this->powerType)) {
+        return 0.0;
+    }
+
+    // Motor's max dynamic braking power is approximately its rated traction power
+    double maxDynamicPower = this->maxPower * 1000.0; // kW to W
+
+    // Dynamic braking fades linearly below 15 km/h (motor can't generate
+    // sufficient back-EMF at very low speeds)
+    double v_kmh = trainSpeed * 3.6;
+    double fadeFactor = std::min(v_kmh / EC::DynamicBrakingFadeSpeed_kmh, 1.0);
+    maxDynamicPower *= fadeFactor;
+
+    return std::min(std::abs(totalBrakingPower), maxDynamicPower);
 }
 
 double Locomotive::getMaxRechargeEnergy(double timeStep, double trainSpeed,

--- a/src/NeTrainSim/traindefinition/locomotive.cpp
+++ b/src/NeTrainSim/traindefinition/locomotive.cpp
@@ -216,7 +216,9 @@ Locomotive::Locomotive(double locomotiveMaxPower_kw,
         this->hybridMethod = TrainTypes::LocomotivePowerMethod::notApplicable;
     }
 
-};	
+    this->brakedWeightRatio = EC::DefaultLocomotiveBrakedWeightRatio;
+
+};
 
 
 double Locomotive::getHyperbolicThrottleCoef(double & trainSpeed)

--- a/src/NeTrainSim/traindefinition/locomotive.h
+++ b/src/NeTrainSim/traindefinition/locomotive.h
@@ -481,6 +481,20 @@ public:
     double getUsedPowerPortion(double trainSpeed,
                                double LocomotiveVirtualTractivePower);
 
+    /**
+     * @brief Gets the recoverable dynamic braking power, capped at motor capacity.
+     *
+     * @details In blended braking, only the dynamic braking portion (motor as generator)
+     * produces recoverable energy. This is capped at the motor's rated power and
+     * fades linearly below 15 km/h where dynamic braking becomes ineffective.
+     *
+     * @param totalBrakingPower  The total braking power magnitude in Watts (positive).
+     * @param trainSpeed         The current train speed in m/s.
+     * @returns The recoverable dynamic braking power in Watts (positive value).
+     */
+    double getRecoverableBrakingPower(double totalBrakingPower,
+                                      double trainSpeed);
+
     void rechargeBatteryByMaxFlow(double timeStep, double trainSpeed,
                                   double powerPortion,
                                   double fuelConversionFactor,

--- a/src/NeTrainSim/traindefinition/train.cpp
+++ b/src/NeTrainSim/traindefinition/train.cpp
@@ -30,7 +30,6 @@ Train::Train(
     : QObject(nullptr)
 {
 
-    this->brakedWeightRatio = DefaultBrakedWeightRatio;
     this->operatorReactionTime = operatorReactionTime_s;
     this->stopTrainIfNoEnergy  = stopIfNoEnergy;
     this->maxJerk              = maxAllowedJerk_mPcs;
@@ -172,39 +171,14 @@ double Train::getMinFollowingTrainGap()
     return DefaultMinFollowingGap;
 }
 
-void Train::setBrakedWeightRatio(double ratio)
-{
-    this->brakedWeightRatio = ratio;
-}
-
-double Train::getAverageTrainGrade()
-{
-    if (this->trainVehicles.empty())
-    {
-        return 0.0;
-    }
-    double sumGrade = 0.0;
-    for (auto &vehicle : this->trainVehicles)
-    {
-        sumGrade += vehicle->trackGrade;
-    }
-    return sumGrade / static_cast<double>(this->trainVehicles.size());
-}
-
 double Train::getDesiredDeceleration(double speed)
 {
-    double muShoe = EC::getBrakeShoeFriction(speed);
-
-    // Brake deceleration: lambda * g * mu_shoe(v)
-    double d_brake = this->brakedWeightRatio * this->g * muShoe;
-
-    // Grade contribution: positive grade (uphill) assists braking
-    double avgGrade = this->getAverageTrainGrade();
-    double d_grade = this->g * avgGrade;
-
-    double d = d_brake + d_grade;
-
-    // Clamp between minimum and wheel-rail adhesion limit
+    double totalBrakingForce = 0.0;
+    for (auto &vehicle : this->trainVehicles)
+    {
+        totalBrakingForce += vehicle->getBrakingForce(speed);
+    }
+    double d = totalBrakingForce / this->totalMass;
     double d_max = this->coefficientOfFriction * this->g;
     return std::max(MinDesiredDeceleration, std::min(d, d_max));
 }

--- a/src/NeTrainSim/traindefinition/train.cpp
+++ b/src/NeTrainSim/traindefinition/train.cpp
@@ -23,7 +23,6 @@ Train::Train(
     double trainStartTime_sec, double frictionCoeff,
     Vector<std::shared_ptr<Locomotive>> locomotives,
     Vector<std::shared_ptr<Car>> cars, bool optimize,
-    double desiredDecelerationRate_mPs,
     double operatorReactionTime_s, bool stopIfNoEnergy,
     double maxAllowedJerk_mPcs, double optimization_k,
     int runOptimizationEvery,
@@ -31,7 +30,7 @@ Train::Train(
     : QObject(nullptr)
 {
 
-    this->d_des = desiredDecelerationRate_mPs;
+    this->brakedWeightRatio = DefaultBrakedWeightRatio;
     this->operatorReactionTime = operatorReactionTime_s;
     this->stopTrainIfNoEnergy  = stopIfNoEnergy;
     this->maxJerk              = maxAllowedJerk_mPcs;
@@ -171,6 +170,43 @@ int Train::getActiveLocomotivesNumber()
 double Train::getMinFollowingTrainGap()
 {
     return DefaultMinFollowingGap;
+}
+
+void Train::setBrakedWeightRatio(double ratio)
+{
+    this->brakedWeightRatio = ratio;
+}
+
+double Train::getAverageTrainGrade()
+{
+    if (this->trainVehicles.empty())
+    {
+        return 0.0;
+    }
+    double sumGrade = 0.0;
+    for (auto &vehicle : this->trainVehicles)
+    {
+        sumGrade += vehicle->trackGrade;
+    }
+    return sumGrade / static_cast<double>(this->trainVehicles.size());
+}
+
+double Train::getDesiredDeceleration(double speed)
+{
+    double muShoe = EC::getBrakeShoeFriction(speed);
+
+    // Brake deceleration: lambda * g * mu_shoe(v)
+    double d_brake = this->brakedWeightRatio * this->g * muShoe;
+
+    // Grade contribution: positive grade (uphill) assists braking
+    double avgGrade = this->getAverageTrainGrade();
+    double d_grade = this->g * avgGrade;
+
+    double d = d_brake + d_grade;
+
+    // Clamp between minimum and wheel-rail adhesion limit
+    double d_max = this->coefficientOfFriction * this->g;
+    return std::max(MinDesiredDeceleration, std::min(d, d_max));
 }
 
 double Train::getBatteryEnergyConsumed()
@@ -640,15 +676,17 @@ double Train::getSafeGap(double initialGap, double speed,
     double gap_lad = 0;
     if (!estimate)
     {
+        double d = this->getDesiredDeceleration(speed);
         gap_lad = initialGap + T_s * speed
                   + (Utils::power(speed, 2)
-                     / (2.0 * this->d_des));
+                     / (2.0 * d));
     }
     else
     {
+        double d = this->getDesiredDeceleration(freeFlowSpeed);
         gap_lad = initialGap + T_s * freeFlowSpeed
                   + (Utils::power(freeFlowSpeed, 2)
-                     / (2.0 * this->d_des));
+                     / (2.0 * d));
     };
     return gap_lad;
 }
@@ -778,11 +816,12 @@ double Train::get_acceleration_an2(
     double gap, double minGap, double speed,
     double leaderSpeed, double T_s, double frictionCoef)
 {
+    double d = this->getDesiredDeceleration(speed);
     double term = 0.0;
     term        = Utils::power(Utils::power(speed, 2)
                                    - Utils::power(leaderSpeed, 2),
                                2)
-           / (4.0 * this->d_des);
+           / (4.0 * d);
     term =
         term / Utils::power(max((gap - minGap), 0.0001), 2);
     return min(term, frictionCoef * this->g);

--- a/src/NeTrainSim/traindefinition/train.cpp
+++ b/src/NeTrainSim/traindefinition/train.cpp
@@ -66,7 +66,7 @@ Train::Train(
                                      Map<int, double>()));
     Train::NumberOfTrainsInSimulator++;
     this->T_s = this->operatorReactionTime
-                + (this->totalLength / this->speedOfSound);
+                + (this->totalLength / this->brakePipePropagationSpeed);
 
     for (auto &car : this->cars)
     {
@@ -179,7 +179,7 @@ double Train::getDesiredDeceleration(double speed)
         totalBrakingForce += vehicle->getBrakingForce(speed);
     }
     double d_physical = totalBrakingForce / this->totalMass;
-    double d = DefaultBrakingComfortFactor * d_physical;
+    double d = DefaultServiceBrakingFactor * d_physical;
     double d_max = this->coefficientOfFriction * this->g;
     return std::max(MinDesiredDeceleration, std::min(d, d_max));
 }

--- a/src/NeTrainSim/traindefinition/train.cpp
+++ b/src/NeTrainSim/traindefinition/train.cpp
@@ -178,7 +178,8 @@ double Train::getDesiredDeceleration(double speed)
     {
         totalBrakingForce += vehicle->getBrakingForce(speed);
     }
-    double d = totalBrakingForce / this->totalMass;
+    double d_physical = totalBrakingForce / this->totalMass;
+    double d = DefaultBrakingComfortFactor * d_physical;
     double d_max = this->coefficientOfFriction * this->g;
     return std::max(MinDesiredDeceleration, std::min(d, d_max));
 }

--- a/src/NeTrainSim/traindefinition/train.h
+++ b/src/NeTrainSim/traindefinition/train.h
@@ -53,8 +53,6 @@ class NETRAINSIMCORE_EXPORT Train : public QObject {
 private:
     /** Holds the number of trains in the simulator. */
     static unsigned int NumberOfTrainsInSimulator;
-    /** (Immutable) the default braked weight ratio (UIC lambda) for freight trains */
-    static constexpr double DefaultBrakedWeightRatio = 0.8;
     /** (Immutable) minimum desired deceleration to prevent infinite safe gaps (m/s^2) */
     static constexpr double MinDesiredDeceleration = 0.05;
     /** (Immutable) the default reaction time of the train operator */
@@ -79,8 +77,6 @@ public:
     static constexpr double speedOfSound = 343.0;
     /** (Immutable) gravitational acceleration */
     const double g = 9.8066;
-    /** The braked weight ratio (UIC lambda). Ratio of braked weight to total weight (0.5-1.0). */
-    double brakedWeightRatio = 0.8;
     /** the perception reaction time of the train operator. */
     double operatorReactionTime;
     /** Total length of the train */
@@ -344,28 +340,16 @@ public:
     double getMinFollowingTrainGap();
 
     /**
-     * @brief Sets the braked weight ratio (UIC lambda).
-     * @param ratio The braked weight ratio (0.5 to 1.0).
-     */
-    void setBrakedWeightRatio(double ratio);
-
-    /**
      * @brief Gets the speed-dependent desired deceleration rate.
      *
-     * @details Uses the ETCS-validated model:
-     *   d(v, grade) = lambda * g * mu_shoe(v) + g * grade
-     * where mu_shoe(v) is the Karwatzki brake shoe friction coefficient.
+     * @details Sums per-vehicle braking forces (Karwatzki model) and divides
+     * by total train mass. Each vehicle uses its own brakedWeightRatio and
+     * trackGrade.
      *
      * @param speed The current train speed in m/s.
      * @returns The desired deceleration in m/s^2.
      */
     double getDesiredDeceleration(double speed);
-
-    /**
-     * @brief Gets the average track grade across all train vehicles.
-     * @returns The average track grade as a decimal (e.g., 0.02 for 2%).
-     */
-    double getAverageTrainGrade();
 
     /**
      * @brief set the current links the train is spanning

--- a/src/NeTrainSim/traindefinition/train.h
+++ b/src/NeTrainSim/traindefinition/train.h
@@ -55,6 +55,10 @@ private:
     static unsigned int NumberOfTrainsInSimulator;
     /** (Immutable) minimum desired deceleration to prevent infinite safe gaps (m/s^2) */
     static constexpr double MinDesiredDeceleration = 0.05;
+    /** Fraction of maximum braking capability used as desired deceleration.
+     *  Scales Karwatzki physical maximum to a comfortable braking rate
+     *  for the car-following safe gap calculation. */
+    static constexpr double DefaultBrakingComfortFactor = 0.15;
     /** (Immutable) the default reaction time of the train operator */
     static constexpr double DefaultOperatorReactionTime = 1.0;
     /** (Immutable) the default switch of the train behaviour if no energy source */
@@ -342,9 +346,11 @@ public:
     /**
      * @brief Gets the speed-dependent desired deceleration rate.
      *
-     * @details Sums per-vehicle braking forces (Karwatzki model) and divides
-     * by total train mass. Each vehicle uses its own brakedWeightRatio and
-     * trackGrade.
+     * @details Computes comfortable braking deceleration for the
+     * car-following safe gap calculation. Sums per-vehicle shoe braking
+     * forces (Karwatzki model), divides by total train mass, then scales
+     * by DefaultBrakingComfortFactor to convert from physical maximum
+     * to a desired comfortable rate.
      *
      * @param speed The current train speed in m/s.
      * @returns The desired deceleration in m/s^2.

--- a/src/NeTrainSim/traindefinition/train.h
+++ b/src/NeTrainSim/traindefinition/train.h
@@ -53,8 +53,10 @@ class NETRAINSIMCORE_EXPORT Train : public QObject {
 private:
     /** Holds the number of trains in the simulator. */
     static unsigned int NumberOfTrainsInSimulator;
-    /** (Immutable) the default desired deceleration rate */
-    static constexpr double DefaultDesiredDecelerationRate = 0.2;
+    /** (Immutable) the default braked weight ratio (UIC lambda) for freight trains */
+    static constexpr double DefaultBrakedWeightRatio = 0.8;
+    /** (Immutable) minimum desired deceleration to prevent infinite safe gaps (m/s^2) */
+    static constexpr double MinDesiredDeceleration = 0.05;
     /** (Immutable) the default reaction time of the train operator */
     static constexpr double DefaultOperatorReactionTime = 1.0;
     /** (Immutable) the default switch of the train behaviour if no energy source */
@@ -77,8 +79,8 @@ public:
     static constexpr double speedOfSound = 343.0;
     /** (Immutable) gravitational acceleration */
     const double g = 9.8066;
-    /** The desired decceleration value */
-    double d_des;
+    /** The braked weight ratio (UIC lambda). Ratio of braked weight to total weight (0.5-1.0). */
+    double brakedWeightRatio = 0.8;
     /** the perception reaction time of the train operator. */
     double operatorReactionTime;
     /** Total length of the train */
@@ -273,15 +275,12 @@ public:
      * @param 	locomotives				   	The locomotives.
      * @param 	cars					   	The cars.
      * @param 	optimize				   	True to optimize.
-     * @param 	desiredDecelerationRate_mPs	(Optional) The desired deceleration rate m ps.
      * @param 	operatorReactionTime_s	   	(Optional) The operator reaction time s.
      * @param 	stopIfNoEnergy			   	(Optional) True to stop if no energy.
-     * @param 	isRunnigOffGrid			   	(Optional) True if is runnig off grid, false if not.
      * @param 	maxAllowedJerk_mPcs		   	(Optional) The maximum allowed jerk m pcs.
      */
     Train(int simulatorID, string id, Vector<int> trainPath, double trainStartTime_sec, double frictionCoeff,
           Vector<std::shared_ptr<Locomotive>> locomotives, Vector<std::shared_ptr<Car>> cars, bool optimize,
-          double desiredDecelerationRate_mPs = DefaultDesiredDecelerationRate,
           double operatorReactionTime_s = DefaultOperatorReactionTime,
           bool stopIfNoEnergy = DefaultStopIfNoEnergy,
           double maxAllowedJerk_mPcs = DefaultMaxAllowedJerk,
@@ -343,6 +342,30 @@ public:
      * @returns	The minimum following train gap.
      */
     double getMinFollowingTrainGap();
+
+    /**
+     * @brief Sets the braked weight ratio (UIC lambda).
+     * @param ratio The braked weight ratio (0.5 to 1.0).
+     */
+    void setBrakedWeightRatio(double ratio);
+
+    /**
+     * @brief Gets the speed-dependent desired deceleration rate.
+     *
+     * @details Uses the ETCS-validated model:
+     *   d(v, grade) = lambda * g * mu_shoe(v) + g * grade
+     * where mu_shoe(v) is the Karwatzki brake shoe friction coefficient.
+     *
+     * @param speed The current train speed in m/s.
+     * @returns The desired deceleration in m/s^2.
+     */
+    double getDesiredDeceleration(double speed);
+
+    /**
+     * @brief Gets the average track grade across all train vehicles.
+     * @returns The average track grade as a decimal (e.g., 0.02 for 2%).
+     */
+    double getAverageTrainGrade();
 
     /**
      * @brief set the current links the train is spanning

--- a/src/NeTrainSim/traindefinition/train.h
+++ b/src/NeTrainSim/traindefinition/train.h
@@ -55,10 +55,10 @@ private:
     static unsigned int NumberOfTrainsInSimulator;
     /** (Immutable) minimum desired deceleration to prevent infinite safe gaps (m/s^2) */
     static constexpr double MinDesiredDeceleration = 0.05;
-    /** Fraction of maximum braking capability used as desired deceleration.
-     *  Scales Karwatzki physical maximum to a comfortable braking rate
-     *  for the car-following safe gap calculation. */
-    static constexpr double DefaultBrakingComfortFactor = 0.15;
+    /** Fraction of emergency braking used for normal service braking.
+     *  0.5 = 50% of max brake force (Karwatzki physical maximum).
+     *  Typical: 0.35 heavy haul, 0.5 freight, 0.65 passenger. */
+    static constexpr double DefaultServiceBrakingFactor = 0.5;
     /** (Immutable) the default reaction time of the train operator */
     static constexpr double DefaultOperatorReactionTime = 1.0;
     /** (Immutable) the default switch of the train behaviour if no energy source */
@@ -75,10 +75,10 @@ private:
 public:
 
     /**
-     * (Immutable) the speed of sound in m / s, this is an approximation of the brackes back
-     * propagation
+     * (Immutable) brake pipe pressure wave propagation speed in m/s.
+     * Measured ~250 m/s for service braking on freight (Qiao 2018).
      */
-    static constexpr double speedOfSound = 343.0;
+    static constexpr double brakePipePropagationSpeed = 250.0;
     /** (Immutable) gravitational acceleration */
     const double g = 9.8066;
     /** the perception reaction time of the train operator. */

--- a/src/NeTrainSim/traindefinition/traincomponent.cpp
+++ b/src/NeTrainSim/traindefinition/traincomponent.cpp
@@ -6,6 +6,14 @@ double TrainComponent::getResistance(double trainSpeed) {
 	return 0.0;
 }
 
+double TrainComponent::getBrakingForce(double trainSpeed) {
+    double muShoe = EC::getBrakeShoeFriction(trainSpeed);
+    double weightKg = this->currentWeight * 1000.0;
+    double F_brake = this->brakedWeightRatio * weightKg * EC::g * muShoe;
+    double F_grade = weightKg * EC::g * this->trackGrade;
+    return F_brake + F_grade;
+}
+
 void TrainComponent::resetTimeStepConsumptions() {
     // reset the energy consumption for the time step.
 	this->energyConsumed = 0.0;

--- a/src/NeTrainSim/traindefinition/traincomponent.cpp
+++ b/src/NeTrainSim/traindefinition/traincomponent.cpp
@@ -9,9 +9,7 @@ double TrainComponent::getResistance(double trainSpeed) {
 double TrainComponent::getBrakingForce(double trainSpeed) {
     double muShoe = EC::getBrakeShoeFriction(trainSpeed);
     double weightKg = this->currentWeight * 1000.0;
-    double F_brake = this->brakedWeightRatio * weightKg * EC::g * muShoe;
-    double F_grade = weightKg * EC::g * this->trackGrade;
-    return F_brake + F_grade;
+    return this->brakedWeightRatio * weightKg * EC::g * muShoe;
 }
 
 void TrainComponent::resetTimeStepConsumptions() {

--- a/src/NeTrainSim/traindefinition/traincomponent.h
+++ b/src/NeTrainSim/traindefinition/traincomponent.h
@@ -98,10 +98,13 @@ public:
 	 * \brief Gets the braking force for this vehicle at the given speed.
 	 *
 	 * \details Computes per-vehicle braking force using the Karwatzki model:
-	 *   F = brakedWeightRatio * weight * g * mu_shoe(v) + weight * g * grade
+	 *   F = brakedWeightRatio * weight * g * mu_shoe(v)
+	 *
+	 * Grade is excluded because it causes discontinuous jumps when vehicles
+	 * cross link boundaries and is already captured in the resistance model.
 	 *
 	 * @param trainSpeed The current train speed in m/s.
-	 * @returns The braking force in Newtons.
+	 * @returns The braking force in Newtons (shoe friction only).
 	 */
 	virtual double getBrakingForce(double trainSpeed);
 

--- a/src/NeTrainSim/traindefinition/traincomponent.h
+++ b/src/NeTrainSim/traindefinition/traincomponent.h
@@ -47,6 +47,8 @@ public:
 	int noOfAxiles;
 	/** Auxiliary power */
 	double auxiliaryPower;
+	/** The braked weight ratio for this vehicle (UIC lambda). Set by subclass constructors. */
+	double brakedWeightRatio = 0.8;
 
     /** The amount of energy consumed in kwh*/
 	double energyConsumed = 0.0;
@@ -91,6 +93,17 @@ public:
 	 * @returns	The resistance.
 	 */
 	virtual double getResistance(double trainSpeed);
+
+	/**
+	 * \brief Gets the braking force for this vehicle at the given speed.
+	 *
+	 * \details Computes per-vehicle braking force using the Karwatzki model:
+	 *   F = brakedWeightRatio * weight * g * mu_shoe(v) + weight * g * grade
+	 *
+	 * @param trainSpeed The current train speed in m/s.
+	 * @returns The braking force in Newtons.
+	 */
+	virtual double getBrakingForce(double trainSpeed);
 
 	/**
 	 * \brief Resets the energy consumptions data for the current time step

--- a/src/NeTrainSim/traindefinition/trainslist.cpp
+++ b/src/NeTrainSim/traindefinition/trainslist.cpp
@@ -260,22 +260,30 @@ std::shared_ptr<Train> TrainsList::generateTrain(
             trainID.fetch_add(1, std::memory_order_acq_rel);
 
         // create a new train and add it to the trains list
-        return std::make_shared<Train>(
+        auto train = std::make_shared<Train>(
             currentID,
             std::any_cast<std::string>(
-                trainRecord["UserID"]), // user id
+                trainRecord["UserID"]),
             std::any_cast<Vector<int>>(
-                trainRecord["TrainPathOnNodeIDs"]), // path
+                trainRecord["TrainPathOnNodeIDs"]),
             std::any_cast<double>(
-                trainRecord["LoadTime"]), // time
+                trainRecord["LoadTime"]),
             std::any_cast<double>(
-                trainRecord["FrictionCoef"]), // friction
-                                              // coef
-            locomotives,                      // locomotives
-            cars,                             // cars
+                trainRecord["FrictionCoef"]),
+            locomotives,
+            cars,
             std::any_cast<bool>(
-                trainRecord["Optimize"]) // no optimization
+                trainRecord["Optimize"])
         );
+
+        // set braked weight ratio if provided
+        if (trainRecord.count("BrakedWeightRatio") > 0) {
+            train->setBrakedWeightRatio(
+                std::any_cast<double>(
+                    trainRecord["BrakedWeightRatio"]));
+        }
+
+        return train;
     }
     catch (std::exception &e)
     {
@@ -488,6 +496,12 @@ TrainsList::readTrainsFromJSON(
             {"Locomotives", locomotiveRecords},
             {"Cars", carRecords},
             {"Optimize", trainObject["Optimize"].toBool()}};
+
+        // add optional braked weight ratio
+        if (trainObject.contains("BrakedWeightRatio")) {
+            trainRecord["BrakedWeightRatio"] =
+                trainObject["BrakedWeightRatio"].toDouble();
+        }
 
         // Add the train record to the list
         trainsRecords.push_back(trainRecord);

--- a/src/NeTrainSim/traindefinition/trainslist.cpp
+++ b/src/NeTrainSim/traindefinition/trainslist.cpp
@@ -276,13 +276,6 @@ std::shared_ptr<Train> TrainsList::generateTrain(
                 trainRecord["Optimize"])
         );
 
-        // set braked weight ratio if provided
-        if (trainRecord.count("BrakedWeightRatio") > 0) {
-            train->setBrakedWeightRatio(
-                std::any_cast<double>(
-                    trainRecord["BrakedWeightRatio"]));
-        }
-
         return train;
     }
     catch (std::exception &e)
@@ -496,12 +489,6 @@ TrainsList::readTrainsFromJSON(
             {"Locomotives", locomotiveRecords},
             {"Cars", carRecords},
             {"Optimize", trainObject["Optimize"].toBool()}};
-
-        // add optional braked weight ratio
-        if (trainObject.contains("BrakedWeightRatio")) {
-            trainRecord["BrakedWeightRatio"] =
-                trainObject["BrakedWeightRatio"].toDouble();
-        }
 
         // Add the train record to the list
         trainsRecords.push_back(trainRecord);

--- a/src/NeTrainSim/traindefinition/traintypes.h
+++ b/src/NeTrainSim/traindefinition/traintypes.h
@@ -559,6 +559,20 @@ namespace TrainTypes {
         }
     }
 
+    /**
+     * *********************************************************************
+     * Brake Shoe Types
+     * *********************************************************************
+     */
+    /** Values that represent brake shoe types */
+    enum class _BrakeShoeType {
+        castIron,
+        composition
+    };
+
+    /** Type of the brake shoe */
+    using BrakeShoeType = _BrakeShoeType;
+
 }
 
 #endif // !carLocTypes_enum

--- a/src/NeTrainSimGUI/gui/netrainsimmainwindow.cpp
+++ b/src/NeTrainSimGUI/gui/netrainsimmainwindow.cpp
@@ -182,6 +182,13 @@ void NeTrainSim::setupGenerals(){
         this->replotHistoryLinks();
     });
 
+    // Replot when switching tabs so that plots on previously hidden
+    // tabs receive their data once visible and laid out.
+    connect(ui->tabWidget_project, &QTabWidget::currentChanged, [this]() {
+        this->replotHistoryNodes();
+        this->replotHistoryLinks();
+    });
+
     // show error if tables has only 1 row
     connect(ui->table_newNodes, &CustomTableWidget::cannotDeleteRow,
             [this]() {
@@ -287,9 +294,12 @@ void NeTrainSim::setupPage1(){
     // add graphs to the plot
     ui->plot_createNetwork->addGraph();
     ui->plot_createNetwork->addGraph();
-    // disable viewing the axies
+    // disable viewing the axes and remove auto margins so the axis rect
+    // always has positive inner dimensions (even on hidden tabs)
     ui->plot_createNetwork->xAxis->setVisible(false);
     ui->plot_createNetwork->yAxis->setVisible(false);
+    ui->plot_createNetwork->axisRect()->setAutoMargins(QCP::msNone);
+    ui->plot_createNetwork->axisRect()->setMargins(QMargins(5, 5, 5, 5));
 
 
     // get the nodes file
@@ -545,9 +555,12 @@ void NeTrainSim::forceReplotLinks() {
 
 
 void NeTrainSim::setupPage2(){
-    // disable viewing the axies
+    // disable viewing the axes and remove auto margins so the axis rect
+    // always has positive inner dimensions (even on hidden tabs)
     ui->plot_trains->xAxis->setVisible(false);
     ui->plot_trains->yAxis->setVisible(false);
+    ui->plot_trains->axisRect()->setAutoMargins(QCP::msNone);
+    ui->plot_trains->axisRect()->setMargins(QMargins(5, 5, 5, 5));
 
     // show the layout as a default
     ui->widget_oldTrainOD->show();
@@ -759,9 +772,12 @@ void NeTrainSim::setupPage3(){
     simulatorWidgetSizes << 229 << 700;
     ui->splitter_simulator->setSizes(simulatorWidgetSizes);
 
-    // disable viewing the axies
+    // disable viewing the axes and remove auto margins so the axis rect
+    // always has positive inner dimensions (even on hidden tabs)
     ui->plot_simulation->xAxis->setVisible(false);
     ui->plot_simulation->yAxis->setVisible(false);
+    ui->plot_simulation->axisRect()->setAutoMargins(QCP::msNone);
+    ui->plot_simulation->axisRect()->setMargins(QMargins(5, 5, 5, 5));
 
     // add graphs to the plot
     auto nodegraph = ui->plot_simulation->addGraph();
@@ -1514,7 +1530,6 @@ void NeTrainSim::updateNodesPlot(CustomPlot &plot, QVector<double>xData,
 
     // clear the graph data
     graph->data()->clear();
-    plot.replot();
 
     if (xData.size() < 1) { return; }
     if (xData.size() != yData.size()) {
@@ -1576,7 +1591,6 @@ void NeTrainSim::updateNodesPlot(CustomPlot &plot, QVector<double>xData,
     }
 
     plot.resetZoom();
-    //plot.replot();
 };
 
 /**
@@ -1764,11 +1778,11 @@ void NeTrainSim::updateLinksPlot(CustomPlot &plot,
                                  QVector<QString> endNodeIDs) {
     // check if the plot has at least 2 graphs
     if (plot.graphCount() < 2) { return; }
+
     // get the QCPGraph object for the graph in the QCustomPlot
     QCPGraph *graph = plot.graph(1);
 
     graph->data()->clear();
-    plot.replot();
 
     if (startNodeIDs.size() != endNodeIDs.size() ||
         startNodeIDs.size() < 1 || this->networkNodes.size() < 1) {
@@ -1798,8 +1812,8 @@ void NeTrainSim::updateLinksPlot(CustomPlot &plot,
     }
     // set the pen style for the lines
     graph->setPen(QPen(Qt::blue, 2));
+
     plot.resetZoom();
-    //plot.replot();
 };
 
 /**


### PR DESCRIPTION
## Summary

This PR introduces a physics-based speed-dependent braking/deceleration model replacing the old constant `d_des = 0.2 m/s²`, fixes regenerative braking energy calculations, and includes build system and GUI fixes.

### Braking & Deceleration Model
- **Karwatzki brake shoe friction model** — added `EC::getBrakeShoeFriction()` implementing the UIC-standard speed-dependent friction: `mu(v) = 0.6*(v+100)/(5v+100)` for cast iron shoes. Added `BrakeShoeType` enum for cast iron vs composition shoes.
- **Per-vehicle braking force** — moved braking force computation from a single train-level average to per-vehicle `TrainComponent::getBrakingForce()`, respecting each vehicle's braked weight ratio (locomotive=0.9, cargo=0.6, tender=0.7).
- **Speed-dependent desired deceleration** — `Train::getDesiredDeceleration(speed)` now sums per-vehicle Karwatzki braking forces and applies a service braking factor (default 0.5 = normal service at 50% of emergency capability). Replaced the old constant `d_des = 0.2`.
- **Grade excluded from braking estimate** — grade caused discontinuous jumps in `d(v)` when vehicles crossed link boundaries; it's already captured by the resistance model (Davis equation).
- **Brake pipe propagation speed corrected** — changed from 343 m/s (free-air speed of sound) to 250 m/s based on measured freight brake pipe propagation (Qiao 2018).

### Blended Braking Fix
- **Motor capacity cap on regenerative braking** — added `Locomotive::getRecoverableBrakingPower()` that caps dynamic braking at the motor's rated power and fades linearly below 15 km/h. Only the recoverable portion (not total braking) is used for energy regeneration calculations.

### Build System
- Build-type-based paths for KDReports and RabbitMQ-C on Linux
- Updated WIN32_EXECUTABLE property for GUI and RabbitMQConfig
- Fixed RabbitMQ DLL copy logic for Windows
- Updated KDReports and Container search paths

### GUI
- Fixed empty plots on hidden tabs (zero-height axisRect from auto margins)
- Added tab-change replot so plots render when switching tabs
- Removed redundant `replot()` calls

### Other
- Application icons and resource handling
- Server-enabled container management in SimulatorAPI
- CO2 emission tracking
- Various smaller fixes

## Test plan
- [ ] Load sample project in GUI, verify nodes/links display on both network plot and Define Trains Paths plot
- [ ] Run simulation, export CSV, verify smooth deceleration profile (no sawtooth oscillation)
- [ ] Verify braking onset distance is reasonable (~1.5-2 km at 162 km/h for freight)
- [ ] Test on Windows build (CMake path changes)